### PR TITLE
Fix README development heading

### DIFF
--- a/frontend-angular/README.md
+++ b/frontend-angular/README.md
@@ -2,7 +2,7 @@
 * `npm install` (installing dependencies)
 * `npm outdated` (verifying dependencies)
 
-### Developpement
+### Development
 * `npm run start`
 * in your browser [http://localhost:4200](http://localhost:4200) 
 


### PR DESCRIPTION
## Summary
- fix a typo in the Development section heading

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm run test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685263708ac083259f197be97e85face