### PR TITLE
Implement Customer module

### DIFF
--- a/backend-java-springboot/src/main/java/com/example/crm/domain/model/Customer.java
+++ b/backend-java-springboot/src/main/java/com/example/crm/domain/model/Customer.java
@@ -7,14 +7,21 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.Instant;
 
 @Entity
-@Table(name = "customers")
+@Table(name = "customers", indexes = {
+        @Index(name = "idx_customer_address_id", columnList = "address_id")
+})
 public class Customer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "first_name")
     private String firstName;
+
+    @Column(name = "last_name")
     private String lastName;
+
+    @Column(name = "email")
     private String email;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend-java-springboot/src/main/java/com/example/crm/service/AddressService.java
+++ b/backend-java-springboot/src/main/java/com/example/crm/service/AddressService.java
@@ -23,6 +23,11 @@ public class AddressService {
     }
 
     @Transactional(readOnly = true)
+    public java.util.List<Address> findAll() {
+        return repository.findAll();
+    }
+
+    @Transactional(readOnly = true)
     public Address findById(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Address not found"));

--- a/backend-java-springboot/src/main/java/com/example/crm/service/CustomerService.java
+++ b/backend-java-springboot/src/main/java/com/example/crm/service/CustomerService.java
@@ -1,0 +1,58 @@
+package com.example.crm.service;
+
+import com.example.crm.domain.model.Customer;
+import com.example.crm.domain.model.Address;
+import com.example.crm.domain.repository.CustomerRepository;
+import com.example.crm.exception.ResourceNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class CustomerService {
+    private final CustomerRepository repository;
+    private final AddressService addressService;
+
+    public CustomerService(CustomerRepository repository, AddressService addressService) {
+        this.repository = repository;
+        this.addressService = addressService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Customer> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Customer findById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Customer not found"));
+    }
+
+    public Customer create(Customer customer) {
+        if (customer.getAddress() != null) {
+            Address addr = addressService.findById(customer.getAddress().getId());
+            customer.setAddress(addr);
+        }
+        return repository.save(customer);
+    }
+
+    public Customer update(Long id, Customer updated) {
+        Customer existing = findById(id);
+        existing.setFirstName(updated.getFirstName());
+        existing.setLastName(updated.getLastName());
+        existing.setEmail(updated.getEmail());
+        if (updated.getAddress() != null) {
+            Address addr = addressService.findById(updated.getAddress().getId());
+            existing.setAddress(addr);
+        }
+        return repository.save(existing);
+    }
+
+    public void delete(Long id) {
+        Customer existing = findById(id);
+        repository.delete(existing);
+    }
+}

--- a/backend-java-springboot/src/main/java/com/example/crm/web/CustomerController.java
+++ b/backend-java-springboot/src/main/java/com/example/crm/web/CustomerController.java
@@ -1,0 +1,62 @@
+package com.example.crm.web;
+
+import com.example.crm.domain.model.Customer;
+import com.example.crm.service.CustomerService;
+import com.example.crm.web.dto.CustomerDto;
+import com.example.crm.web.dto.CustomerMapper;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/customers")
+public class CustomerController {
+
+    private final CustomerService service;
+    private final CustomerMapper mapper;
+
+    public CustomerController(CustomerService service, CustomerMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    @GetMapping
+    public Page<CustomerDto> list(
+            @Parameter(in = ParameterIn.QUERY, description = "Page number (0-based)", example = "0", required = false)
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @Parameter(in = ParameterIn.QUERY, description = "Page size", example = "10", required = false)
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @Parameter(in = ParameterIn.QUERY, description = "Sort criteria (field,direction)", example = "lastName,asc", required = false)
+            @RequestParam(required = false, defaultValue = "id,asc") String sort,
+            @PageableDefault(size = 10, sort = "id") Pageable pageable) {
+        return service.findAll(pageable).map(mapper::toDto);
+    }
+
+    @GetMapping("/{id}")
+    public CustomerDto get(@PathVariable Long id) {
+        return mapper.toDto(service.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<CustomerDto> create(@Valid @RequestBody CustomerDto dto) {
+        Customer saved = service.create(mapper.toEntity(dto));
+        return ResponseEntity.created(null).body(mapper.toDto(saved));
+    }
+
+    @PutMapping("/{id}")
+    public CustomerDto update(@PathVariable Long id, @Valid @RequestBody CustomerDto dto) {
+        Customer updated = service.update(id, mapper.toEntity(dto));
+        return mapper.toDto(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend-java-springboot/src/main/java/com/example/crm/web/dto/CustomerDto.java
+++ b/backend-java-springboot/src/main/java/com/example/crm/web/dto/CustomerDto.java
@@ -1,9 +1,12 @@
 package com.example.crm.web.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 public record CustomerDto(
         Long id,
-        String firstName,
-        String lastName,
-        String email,
+        @NotBlank String firstName,
+        @NotBlank String lastName,
+        @Email @NotBlank String email,
         Long addressId
 ) {}

--- a/backend-java-springboot/src/main/java/com/example/crm/web/dto/CustomerMapper.java
+++ b/backend-java-springboot/src/main/java/com/example/crm/web/dto/CustomerMapper.java
@@ -1,0 +1,14 @@
+package com.example.crm.web.dto;
+
+import com.example.crm.domain.model.Customer;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CustomerMapper {
+    @Mapping(target = "addressId", source = "address.id")
+    CustomerDto toDto(Customer entity);
+
+    @Mapping(target = "address.id", source = "addressId")
+    Customer toEntity(CustomerDto dto);
+}

--- a/backend-java-springboot/src/test/java/com/example/crm/web/CustomerControllerTest.java
+++ b/backend-java-springboot/src/test/java/com/example/crm/web/CustomerControllerTest.java
@@ -1,0 +1,68 @@
+package com.example.crm.web;
+
+import com.example.crm.domain.model.Customer;
+import com.example.crm.service.CustomerService;
+import com.example.crm.web.dto.CustomerDto;
+import com.example.crm.web.dto.CustomerMapper;
+import com.example.crm.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CustomerController.class)
+public class CustomerControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    CustomerService service;
+
+    @MockBean
+    CustomerMapper mapper;
+
+    @Test
+    void list_returnsOk() throws Exception {
+        Customer customer = new Customer();
+        Mockito.when(service.findAll(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(customer)));
+        Mockito.when(mapper.toDto(any(Customer.class)))
+                .thenReturn(new CustomerDto(1L, "John", "Doe", "john@doe.com", 1L));
+
+        mockMvc.perform(get("/api/v1/customers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content").isArray());
+    }
+
+    @Test
+    void create_unknownAddress_returnsNotFound() throws Exception {
+        Mockito.when(service.create(any(Customer.class)))
+                .thenThrow(new ResourceNotFoundException("Address not found"));
+        String json = "{\"firstName\":\"A\",\"lastName\":\"B\",\"email\":\"a@b.com\",\"addressId\":99}";
+        mockMvc.perform(post("/api/v1/customers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void create_validationError_returnsBadRequest() throws Exception {
+        String json = "{}";
+        mockMvc.perform(post("/api/v1/customers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/frontend-angular/src/app/app.routes.ts
+++ b/frontend-angular/src/app/app.routes.ts
@@ -13,7 +13,7 @@ export const routes: Routes = [
     component: MainLayoutComponent,
     children: [
       { path: 'addresses', canActivate: [authGuard], loadChildren: () => import('./modules/features/address/address.routes').then(mod => mod.routes) },
-      { path: 'customers', canActivate: [authGuard], loadComponent: () => import('./modules/general/not-found/not-found').then(mod => mod.NotFound) },
+      { path: 'customers', canActivate: [authGuard], loadChildren: () => import('./modules/features/customer/customer.routes').then(mod => mod.routes) },
       { path: 'products', canActivate: [authGuard], loadComponent: () => import('./modules/general/not-found/not-found').then(mod => mod.NotFound) },
       { path: 'orders', canActivate: [authGuard], loadComponent: () => import('./modules/general/not-found/not-found').then(mod => mod.NotFound) }
     ]

--- a/frontend-angular/src/app/modules/features/customer/customer.routes.ts
+++ b/frontend-angular/src/app/modules/features/customer/customer.routes.ts
@@ -1,0 +1,6 @@
+import { Routes } from '@angular/router';
+import { CustomerListComponent } from './list/customer-list.component';
+
+export const routes: Routes = [
+  { path: '', component: CustomerListComponent }
+];

--- a/frontend-angular/src/app/modules/features/customer/dialog/customer-dialog.component.html
+++ b/frontend-angular/src/app/modules/features/customer/dialog/customer-dialog.component.html
@@ -1,0 +1,27 @@
+<h1 mat-dialog-title>{{ data ? 'Edit' : 'Add' }} Customer</h1>
+<form [formGroup]="form" (ngSubmit)="submit()" mat-dialog-content>
+  <mat-form-field appearance="fill">
+    <mat-label>First Name</mat-label>
+    <input matInput formControlName="firstName" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Last Name</mat-label>
+    <input matInput formControlName="lastName" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Email</mat-label>
+    <input matInput formControlName="email" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Address</mat-label>
+    <mat-select formControlName="addressId">
+      <mat-option *ngFor="let a of (addresses$ | async)?.content" [value]="a.id">
+        {{ a.street }} - {{ a.city }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+  <div mat-dialog-actions align="end">
+    <button mat-button (click)="cancel()">Cancel</button>
+    <button mat-flat-button color="primary" [disabled]="form.invalid">Save</button>
+  </div>
+</form>

--- a/frontend-angular/src/app/modules/features/customer/dialog/customer-dialog.component.spec.ts
+++ b/frontend-angular/src/app/modules/features/customer/dialog/customer-dialog.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CustomerDialogComponent } from './customer-dialog.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { AddressService } from '../../address/services/address.service';
+
+describe('CustomerDialogComponent', () => {
+  let component: CustomerDialogComponent;
+  let fixture: ComponentFixture<CustomerDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, CustomerDialogComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: null },
+        { provide: MatDialogRef, useValue: { close: () => {} } },
+        AddressService
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomerDialogComponent);
+    component = fixture.componentInstance;
+    spyOn(component['addressService'], 'getAll').and.returnValue(of({ content: [], totalElements: 0 }));
+    fixture.detectChanges();
+  });
+
+  it('form invalid when empty', () => {
+    expect(component.form.valid).toBeFalse();
+  });
+});

--- a/frontend-angular/src/app/modules/features/customer/dialog/customer-dialog.component.ts
+++ b/frontend-angular/src/app/modules/features/customer/dialog/customer-dialog.component.ts
@@ -1,0 +1,69 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { CustomerService } from '../services/customer.service';
+import { Customer } from '../services/customer.model';
+import { AddressService } from '../../address/services/address.service';
+import { AddressPage } from '../../address/services/address.model';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-customer-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSelectModule
+  ],
+  templateUrl: './customer-dialog.component.html',
+  styleUrl: './customer-dialog.component.css'
+})
+export class CustomerDialogComponent {
+  form!: FormGroup;
+  addresses$!: Observable<AddressPage>;
+
+  constructor(
+    private fb: FormBuilder,
+    private service: CustomerService,
+    private addressService: AddressService,
+    private dialogRef: MatDialogRef<CustomerDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: Customer | null
+  ) {
+    this.form = this.fb.group({
+      id: [],
+      firstName: ['', Validators.required],
+      lastName: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      addressId: []
+    });
+
+    if (data) {
+      this.form.patchValue(data);
+    }
+
+    this.addresses$ = this.addressService.getAll();
+  }
+
+  submit() {
+    if (this.form.invalid) {
+      return;
+    }
+    this.service.save(this.form.value as Customer).subscribe({
+      next: res => this.dialogRef.close(res),
+      error: () => this.dialogRef.close(null)
+    });
+  }
+
+  cancel() {
+    this.dialogRef.close(null);
+  }
+}

--- a/frontend-angular/src/app/modules/features/customer/list/customer-list.component.html
+++ b/frontend-angular/src/app/modules/features/customer/list/customer-list.component.html
@@ -1,0 +1,38 @@
+<div fxLayout="column" fxLayoutGap="10px">
+  <div fxLayout="row" fxLayoutAlign="end center">
+    <button mat-raised-button color="primary" (click)="openDialog()">Add Customer</button>
+  </div>
+  <table mat-table [dataSource]="dataSource" matSort>
+    <ng-container matColumnDef="firstName">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>First</th>
+      <td mat-cell *matCellDef="let element">{{element.firstName}}</td>
+    </ng-container>
+    <ng-container matColumnDef="lastName">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Last</th>
+      <td mat-cell *matCellDef="let element">{{element.lastName}}</td>
+    </ng-container>
+    <ng-container matColumnDef="email">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
+      <td mat-cell *matCellDef="let element">{{element.email}}</td>
+    </ng-container>
+    <ng-container matColumnDef="street">
+      <th mat-header-cell *matHeaderCellDef>Street</th>
+      <td mat-cell *matCellDef="let element">{{element.street}}</td>
+    </ng-container>
+    <ng-container matColumnDef="city">
+      <th mat-header-cell *matHeaderCellDef>City</th>
+      <td mat-cell *matCellDef="let element">{{element.city}}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let element">
+        <button mat-icon-button (click)="openDialog(element)">
+          <mat-icon>edit</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  </table>
+  <mat-paginator [pageSize]="10"></mat-paginator>
+</div>

--- a/frontend-angular/src/app/modules/features/customer/list/customer-list.component.spec.ts
+++ b/frontend-angular/src/app/modules/features/customer/list/customer-list.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CustomerListComponent } from './customer-list.component';
+import { CustomerService } from '../services/customer.service';
+import { of } from 'rxjs';
+
+describe('CustomerListComponent', () => {
+  let component: CustomerListComponent;
+  let fixture: ComponentFixture<CustomerListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, CustomerListComponent],
+      providers: [CustomerService]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomerListComponent);
+    component = fixture.componentInstance;
+    spyOn(component['service'], 'list').and.returnValue(of({ content: [], totalElements: 0 }));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend-angular/src/app/modules/features/customer/list/customer-list.component.ts
+++ b/frontend-angular/src/app/modules/features/customer/list/customer-list.component.ts
@@ -1,0 +1,70 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { CustomerService } from '../services/customer.service';
+import { Customer } from '../services/customer.model';
+import { CustomerDialogComponent } from '../dialog/customer-dialog.component';
+
+@Component({
+  selector: 'app-customer-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FlexLayoutModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatSnackBarModule,
+    CustomerDialogComponent
+  ],
+  templateUrl: './customer-list.component.html',
+  styleUrl: './customer-list.component.css'
+})
+export class CustomerListComponent implements OnInit {
+  displayedColumns = ['firstName', 'lastName', 'email', 'street', 'city', 'actions'];
+  dataSource = new MatTableDataSource<Customer>([]);
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(private service: CustomerService, private dialog: MatDialog, private snack: MatSnackBar) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.service.list().subscribe({
+      next: res => {
+        this.dataSource.data = res.content;
+        this.dataSource.paginator = this.paginator;
+        this.dataSource.sort = this.sort;
+      },
+      error: () => this.snack.open('Failed to load customers', 'Close', { duration: 3000 })
+    });
+  }
+
+  openDialog(customer?: Customer) {
+    const ref = this.dialog.open(CustomerDialogComponent, { data: customer });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.load();
+        this.snack.open('Customer saved', 'Close', { duration: 3000 });
+      }
+    });
+  }
+}

--- a/frontend-angular/src/app/modules/features/customer/services/customer.model.ts
+++ b/frontend-angular/src/app/modules/features/customer/services/customer.model.ts
@@ -1,0 +1,18 @@
+export interface Customer {
+  id?: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  addressId?: number | null;
+}
+
+export interface CustomerPage {
+  content: Customer[];
+  totalElements: number;
+}
+
+export interface CustomerFilters {
+  page?: number | null;
+  size?: number | null;
+  sort?: string | null;
+}

--- a/frontend-angular/src/app/modules/features/customer/services/customer.service.spec.ts
+++ b/frontend-angular/src/app/modules/features/customer/services/customer.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { CustomerService } from './customer.service';
+import { environment } from '../../../../../environments/environment';
+import { API_BASE_URL } from '../../../../shared/constants/api.constants';
+import { Customer } from './customer.model';
+
+describe('CustomerService', () => {
+  let service: CustomerService;
+  let httpMock: HttpTestingController;
+  const baseUrl = `${environment.backend}${API_BASE_URL}/customers`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(CustomerService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should list customers', () => {
+    const mock: Customer[] = [{ id: 1, firstName: 'A', lastName: 'B', email: 'a@b.com' }];
+
+    service.list().subscribe(res => {
+      expect(res.content.length).toBe(1);
+    });
+
+    const req = httpMock.expectOne(`${baseUrl}`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ content: mock, totalElements: 1 });
+  });
+});

--- a/frontend-angular/src/app/modules/features/customer/services/customer.service.ts
+++ b/frontend-angular/src/app/modules/features/customer/services/customer.service.ts
@@ -1,0 +1,28 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../../environments/environment';
+import { API_BASE_URL } from '../../../../shared/constants/api.constants';
+import { Customer, CustomerPage, CustomerFilters } from './customer.model';
+
+@Injectable({ providedIn: 'root' })
+export class CustomerService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.backend}${API_BASE_URL}/customers`;
+
+  list(filters: CustomerFilters = {}): Observable<CustomerPage> {
+    const params = new URLSearchParams();
+    if (filters.page != null) params.set('page', String(filters.page));
+    if (filters.size != null) params.set('size', String(filters.size));
+    if (filters.sort) params.set('sort', filters.sort);
+    const query = params.toString();
+    return this.http.get<CustomerPage>(`${this.baseUrl}${query ? '?' + query : ''}`);
+  }
+
+  save(customer: Customer): Observable<Customer> {
+    if (customer.id) {
+      return this.http.put<Customer>(`${this.baseUrl}/${customer.id}`, customer);
+    }
+    return this.http.post<Customer>(this.baseUrl, customer);
+  }
+}


### PR DESCRIPTION
## Summary
- add validation to `CustomerDto`
- map struct mapper and service/controller for Customer
- extend `AddressService` with non-paged `findAll`
- expose `/customers` route in Angular with list and dialog components
- add specs for Customer service and components

## Testing
- `chmod +x mvnw && ./mvnw -q test` *(fails: could not resolve parent POM)*
- `npm test --silent` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852a65af4c883259ac3f674c3c9fb47